### PR TITLE
Replace archived action-rs/toolchain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y gcc-mingw-w64-x86-64
 
-      - uses: actions-rs/toolchain@v1.0.7
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
           target: x86_64-pc-windows-gnu


### PR DESCRIPTION
The following warning pops up in the workflow with this archived action.

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ 

I pick the alternative from [actions-rs/toolchain#216#issuecomment-1184809175](https://github.com/actions-rs/toolchain/issues/216#issuecomment-1184809175)