### PR TITLE
Replace `fail_on_error: true` with `fail_level: any`

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -17,4 +17,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
           filter_mode: nofilter
-          fail_on_error: true
+          fail_level: any


### PR DESCRIPTION
Follow official suggestions replacing the deprecated input with an equivalent one.

https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md#rotating_light-deprecation-warnings

![image](https://github.com/user-attachments/assets/80336127-56e3-4988-9e3c-b074a15d4171)

According to the suggestion, the input `fail_level` should set to `any` to reproduce the same behavior when the input `reporter` is set to the value other than `github-[pr-]check`.