### PR TITLE
Replace all action-rs actions with alternatives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y gcc-mingw-w64-x86-64
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
           target: x86_64-pc-windows-gnu
@@ -28,18 +28,17 @@ jobs:
         uses: Swatinem/rust-cache@v2.7.8
 
       - name: clippy check
-        uses: actions-rs/clippy-check@v1.0.7
+        uses: clechasseur/rs-clippy-check@v4.0.2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features
 
       - name: install cargo-license
-        uses: actions-rs/cargo@v1.0.3
+        uses: clechasseur/rs-cargo@v3.0.3
         with:
           command: install
           args: cargo-license
 
-      - uses: actions-rs/cargo@v1.0.3
+      - uses: clechasseur/rs-cargo@v3.0.3
         with:
           command: build
           args: --release --target x86_64-pc-windows-gnu

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -22,7 +22,7 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y gcc-mingw-w64-x86-64
 
-      - uses: actions-rs/toolchain@v1.0.7
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
           components: clippy
@@ -33,7 +33,6 @@ jobs:
         uses: Swatinem/rust-cache@v2.7.8
 
       - name: clippy check
-        uses: actions-rs/clippy-check@v1.0.7
+        uses: clechasseur/rs-clippy-check@v4.0.2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features


### PR DESCRIPTION
All action-rs actions is dropped due to its outdated state.
They are using NodeJS 12, which has been dropped by GitHub for some years.
They are currently forced running in NodeJS 20 according to their announcement.
Since I've found alternatives for all of them, this PR altered them.
Some highlights of this PR are listed below.

First, dtolnay/rust-toolchain@master is replaced due to very limited documentation.

The parameter `override` is removed in dtolnay/rust-toolchain.
This breaks the one used in review.yml if the modification on inputs is not allowed.
Due to limited documentation and my own limited understanding, I replaced it with an alternative to avoid modifying original inputs.

One other thing that might worth mentioning is the removal of `token` on rs-clippy-check.
This is a change of this alternative when it releases v2.

https://github.com/clechasseur/rs-clippy-check/releases/tag/v2.0.0
![image](https://github.com/user-attachments/assets/8eb1fe95-4d87-49f3-988d-5556b2f3f909)

